### PR TITLE
Revert "Update main.yml"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
             // Get reviewers
             const reviewers = [...new Set(reviews.data.map(review => review.user.login))];
 
-            core.setOutput('comment_count', comments.data.length.toString());
+            core.setOutput('comment_count', comments.data.length);
             core.setOutput('unique_commenters', uniqueCommenters.join(', '));
             core.setOutput('last_five_comments', lastFiveComments.join(' | '));
             core.setOutput('reviewers', reviewers.join(', '));
@@ -76,10 +76,10 @@ jobs:
             const linesDeleted = process.env.lines_deleted;
             const days = process.env.days;
             const hours = process.env.hours;
-             const commentCount = '${{ steps.comment_review_data.outputs.comment_count }}';
-            const uniqueCommenters = '${{ steps.comment_review_data.outputs.unique_commenters }}';
-            const lastFiveComments = '${{ steps.comment_review_data.outputs.last_five_comments }}';
-            const reviewers = '${{ steps.comment_review_data.outputs.reviewers }}';
+            const commentCount = core.getInput('comment_count');
+            const uniqueCommenters = core.getInput('unique_commenters');
+            const lastFiveComments = core.getInput('last_five_comments');
+            const reviewers = core.getInput('reviewers');
 
             const durationString = days > 0 
               ? `${days} day(s) and ${hours} hour(s)` 


### PR DESCRIPTION
This pull request makes updates to the `.github/workflows/main.yml` file to improve how workflow outputs are handled. The changes include switching from string interpolation to `core.getInput` for retrieving workflow outputs and ensuring consistency in data types for outputs.

### Workflow output handling improvements:

* Updated the `comment_count` output to use a number type instead of a string, ensuring consistency in data handling. (`.github/workflows/main.yml`, [.github/workflows/main.ymlL65-R65](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L65-R65))
* Replaced string interpolation with `core.getInput` for retrieving workflow outputs (`comment_count`, `unique_commenters`, `last_five_comments`, and `reviewers`) to align with best practices for accessing inputs in GitHub Actions. (`.github/workflows/main.yml`, [.github/workflows/main.ymlL79-R82](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L79-R82))